### PR TITLE
fix graph clearing

### DIFF
--- a/lib/conll.py
+++ b/lib/conll.py
@@ -213,7 +213,7 @@ class DependencyTree(nx.DiGraph):
         
         comment = self.graph['comment']
         #4A Quick removal of edges and nodes
-        self.__init__()
+        self.clear()
 
         #4B Rewriting the Deptree in Self
         # TODO There must a more elegant way to rewrite self -- self= T for instance?


### PR DESCRIPTION
`self.__init__()` do not clear graph for me, `clear` is the proper way to do that